### PR TITLE
fix: fix password input type, ignore email/number type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,10 +6,16 @@
 
 interface FocusTrapTest { (element: Element): boolean }
 
-// this query is adapted from via a11y-dialog
+// This query is adapted from a11y-dialog
+// https://github.com/edenspiekermann/a11y-dialog/blob/cf4ed81/a11y-dialog.js#L6-L18
 var focusablesQuery = 'a[href], area[href], input, select, textarea, ' +
   'button, iframe, object, embed, [contenteditable], [tabindex], video[controls], audio[controls]'
-var textInputTypes = ['text', 'search', 'number', 'email', 'url']
+
+// TODO: email/number types are a special type, in that they return selectionStart/selectionEnd as null
+// As far as I can tell, there is no way to actually get the caret position from these inputs. So we
+// don't do the proper caret handling for those inputs, unfortunately.
+var textInputTypes = ['text', 'search', 'url', 'password']
+
 var checkboxRadioInputTypes = ['checkbox', 'radio']
 
 var focusTrapTest: FocusTrapTest = undefined

--- a/test/test.js
+++ b/test/test.js
@@ -29,7 +29,7 @@ function isTextInput (element) {
   const tagName = element.tagName
   const isTextarea = tagName === 'TEXTAREA'
   const isTextInput = tagName === 'INPUT' &&
-    ['text', 'search', 'number', 'email', 'url'].indexOf(
+    ['text', 'search', 'url', 'password'].indexOf(
       element.getAttribute('type').toLowerCase()) !== -1
   const isContentEditable = element.hasAttribute('contenteditable')
   return isTextarea || isTextInput || isContentEditable
@@ -148,6 +148,32 @@ describe('test suite', () => {
       assert(!$('.input-3').checked, 'not checked originally')
       typeEnter()
       assert($('.input-3').checked, 'checked after pressing enter')
+    })
+
+    it('handles url/search/password inputs correctly', () => {
+      document.body.innerHTML = `<div class=container>
+        <input type="search" class="input-1">
+        <input type="url" class="input-2">
+        <input type="password" class="input-3">
+        <input type="text" class="input-4">
+      </div>`
+      $('.input-1').value = 'bar'
+      $('.input-2').value = 'a.com'
+      $('.input-3').value = 'psst'
+      for (let i = 0; i < 4; i++) {
+        typeRight()
+        assertActiveClass(['input-1'])
+      }
+      for (let i = 0; i < 6; i++) {
+        typeRight()
+        assertActiveClass(['input-2'])
+      }
+      for (let i = 0; i < 5; i++) {
+        typeRight()
+        assertActiveClass(['input-3'])
+      }
+      typeRight()
+      assertActiveClass(['input-4'])
     })
 
     // TODO: can't actually test contenteditable in jsdom: https://github.com/jsdom/jsdom/issues/2472


### PR DESCRIPTION
It turns out that email/number types don't report selectionStart/selectionEnd, and I had forgotten about the `password` type. This fixes both of those.