### PR TITLE
fix: handle input type=tel correctly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,8 @@ var focusablesQuery = 'a[href], area[href], input, select, textarea, ' +
 // TODO: email/number types are a special type, in that they return selectionStart/selectionEnd as null
 // As far as I can tell, there is no way to actually get the caret position from these inputs. So we
 // don't do the proper caret handling for those inputs, unfortunately.
-var textInputTypes = ['text', 'search', 'url', 'password']
+// https://html.spec.whatwg.org/multipage/input.html#do-not-apply
+var textInputTypes = ['text', 'search', 'url', 'password', 'tel']
 
 var checkboxRadioInputTypes = ['checkbox', 'radio']
 

--- a/test/test.js
+++ b/test/test.js
@@ -29,7 +29,7 @@ function isTextInput (element) {
   const tagName = element.tagName
   const isTextarea = tagName === 'TEXTAREA'
   const isTextInput = tagName === 'INPUT' &&
-    ['text', 'search', 'url', 'password'].indexOf(
+    ['text', 'search', 'url', 'password', 'tel'].indexOf(
       element.getAttribute('type').toLowerCase()) !== -1
   const isContentEditable = element.hasAttribute('contenteditable')
   return isTextarea || isTextInput || isContentEditable
@@ -150,16 +150,18 @@ describe('test suite', () => {
       assert($('.input-3').checked, 'checked after pressing enter')
     })
 
-    it('handles url/search/password inputs correctly', () => {
+    it('handles url/search/password/tel inputs correctly', () => {
       document.body.innerHTML = `<div class=container>
         <input type="search" class="input-1">
         <input type="url" class="input-2">
         <input type="password" class="input-3">
-        <input type="text" class="input-4">
+        <input type="tel" class="input-4">
+        <input type="text" class="input-5">
       </div>`
       $('.input-1').value = 'bar'
       $('.input-2').value = 'a.com'
       $('.input-3').value = 'psst'
+      $('.input-4').value = '123'
       for (let i = 0; i < 4; i++) {
         typeRight()
         assertActiveClass(['input-1'])
@@ -172,8 +174,12 @@ describe('test suite', () => {
         typeRight()
         assertActiveClass(['input-3'])
       }
+      for (let i = 0; i < 4; i++) {
+        typeRight()
+        assertActiveClass(['input-4'])
+      }
       typeRight()
-      assertActiveClass(['input-4'])
+      assertActiveClass(['input-5'])
     })
 
     // TODO: can't actually test contenteditable in jsdom: https://github.com/jsdom/jsdom/issues/2472


### PR DESCRIPTION
I forgot about the `tel` type; that should be the last one that actually supports selectionStart/selectionEnd.

https://html.spec.whatwg.org/multipage/input.html#do-not-apply