### PR TITLE
fix: handle inert attribute correctly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,9 @@ function getFocusableElements (activeElement) {
   for (var i = 0; i < len; i++) {
     var element = elements[i]
     if (element === activeElement || (
-        !element.disabled && !/^-/.test(element.getAttribute('tabindex') || '') &&
+        !element.disabled &&
+        !/^-/.test(element.getAttribute('tabindex') || '') &&
+        !element.hasAttribute('inert') && // see https://github.com/GoogleChrome/inert-polyfill
         (element.offsetWidth > 0 || element.offsetHeight > 0)
     )) {
       res.push(element)

--- a/test/test.js
+++ b/test/test.js
@@ -176,6 +176,20 @@ describe('test suite', () => {
       assertActiveClass(['input-4'])
     })
 
+    it('skips inert elements', () => {
+      document.body.innerHTML = `<div class=container>
+        <button class="button-1">hey</button>
+        <button class="button-2" inert>hello</button>
+        <button class="button-3">yo</button>
+      </div>`
+      typeRight()
+      assertActiveClass(['button-1'])
+      typeRight()
+      assertActiveClass(['button-3'])
+      typeLeft()
+      assertActiveClass(['button-1'])
+    })
+
     // TODO: can't actually test contenteditable in jsdom: https://github.com/jsdom/jsdom/issues/2472
     it.skip('handles contenteditable correctly', () => {
       document.body.innerHTML = `<div class=container>


### PR DESCRIPTION
The `inert` attribute is apparently a thing, even if it's in draft: https://github.com/GoogleChrome/inert-polyfill