### PR TITLE
feat: shadow dom support using tree walker

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The basic idea is to make the <kbd>←</kbd> and <kbd>→</kbd> keys act similar
 Since the <kbd>↑</kbd> and <kbd>↓</kbd> keys typically scroll the page in KaiOS, this is usually all you need
 to add basic KaiOS accessibility to an existing web app.
 
-It will also listen for the <kbd>Enter</kbd> key for certain special cases like checkbox/radio buttons.
+It will also listen for the <kbd>Enter</kbd> key for certain special cases like checkbox/radio buttons. `contenteditable` and Shadow DOM are also supported.
 
 ## Install
 

--- a/index.html
+++ b/index.html
@@ -66,6 +66,76 @@
         <input type="radio" name="radio" value="radio2">
     </label>
 </div>
+<div>
+    <open-component></open-component>
+</div>
+<div>
+    <closed-component></closed-component>
+</div>
+<div>
+    <my-component-2></my-component-2>
+</div>
+<div>
+    <input type="text" value="hi">
+</div>
+<script>
+    class OpenComponent extends HTMLElement {
+        constructor() {
+            super()
+            this.attachShadow({ mode: 'open' })
+            this.shadowRoot.innerHTML = `
+            <h2>open shadow</h2>
+            <input type="text" value="one">
+            <input type="text" value="two">
+            <input type="text" value="three">
+            `
+        }
+    }
+    class ClosedComponent extends HTMLElement {
+        constructor() {
+            super()
+            const root = this.attachShadow({ mode: 'closed' })
+            root.innerHTML = `
+            <h2>closed shadow</h2>
+            <input type="text" value="one">
+            <input type="text" value="two">
+            <input type="text" value="three">
+            `
+        }
+    }
+
+    class Component2 extends HTMLElement {
+        constructor() {
+            super()
+            this.attachShadow({ mode: 'open'})
+            this.shadowRoot.innerHTML = `
+            <span>not focusable</span>
+            <my-component-3></my-component-3>
+            <span>not focusable</span>
+          `
+            this.classList.add('my-component-2')
+        }
+    }
+
+    class Component3 extends HTMLElement {
+        constructor() {
+            super()
+            this.attachShadow({ mode: 'open'})
+            this.shadowRoot.innerHTML = `
+            <span>not focusable</span>
+            <button class="inside-shadow-button">my button</button>
+            <span>not focusable</span>
+          `
+            this.classList.add('my-component-2')
+        }
+    }
+
+    customElements.define('my-component-2', Component2)
+    customElements.define('my-component-3', Component3)
+    customElements.define('open-component', OpenComponent)
+    customElements.define('closed-component', ClosedComponent)
+</script>
+
 <script src="pkg/dist-umd/index.js"></script>
 <script>
   arrowKeyNavigation.register()

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,12 +6,6 @@
 
 interface FocusTrapTest { (element: Element): boolean }
 
-// This query is adapted from a11y-dialog
-// https://github.com/edenspiekermann/a11y-dialog/blob/cf4ed81/a11y-dialog.js#L6-L18
-var focusablesQuery = 'a[href], area[href], input, select, textarea, ' +
-  'button, iframe, object, embed, [contenteditable], [tabindex], ' +
-  'video[controls], audio[controls], summary'
-
 // TODO: email/number types are a special type, in that they return selectionStart/selectionEnd as null
 // As far as I can tell, there is no way to actually get the caret position from these inputs. So we
 // don't do the proper caret handling for those inputs, unfortunately.
@@ -22,27 +16,26 @@ var checkboxRadioInputTypes = ['checkbox', 'radio']
 
 var focusTrapTest: FocusTrapTest = undefined
 
-function getFocusableElements (activeElement) {
-  // Respect focus trap inside of dialogs
-  var dialogParent = getFocusTrapParent(activeElement)
-  var root = dialogParent || document
+// This query is adapted from a11y-dialog
+// https://github.com/edenspiekermann/a11y-dialog/blob/cf4ed81/a11y-dialog.js#L6-L18
+var focusablesQuery = 'a[href], area[href], input, select, textarea, ' +
+    'button, iframe, object, embed, [contenteditable], [tabindex], ' +
+    'video[controls], audio[controls], summary'
 
-  var res = []
-  var elements = root.querySelectorAll(focusablesQuery)
-
-  var len = elements.length
-  for (var i = 0; i < len; i++) {
-    var element = elements[i]
-    if (element === activeElement || (
-        !element.disabled &&
-        !/^-/.test(element.getAttribute('tabindex') || '') &&
-        !element.hasAttribute('inert') && // see https://github.com/GoogleChrome/inert-polyfill
-        (element.offsetWidth > 0 || element.offsetHeight > 0)
-    )) {
-      res.push(element)
-    }
+function getActiveElement () {
+  var activeElement = document.activeElement
+  while (activeElement.shadowRoot) {
+    activeElement = activeElement.shadowRoot.activeElement
   }
-  return res
+  return activeElement
+}
+
+function isFocusable (element) {
+  return element.matches(focusablesQuery) &&
+    !element.disabled &&
+    !/^-/.test(element.getAttribute('tabindex') || '') &&
+    !element.hasAttribute('inert') && // see https://github.com/GoogleChrome/inert-polyfill
+    (element.offsetWidth > 0 || element.offsetHeight > 0)
 }
 
 function getFocusTrapParent (element) {
@@ -58,7 +51,7 @@ function getFocusTrapParent (element) {
   }
 }
 
-function shouldIgnoreEvent (activeElement, key) {
+function shouldIgnoreEvent (activeElement, forwardDirection) {
   var tagName = activeElement.tagName
   var isTextarea = tagName === 'TEXTAREA'
   var isTextInput = tagName === 'INPUT' &&
@@ -85,36 +78,61 @@ function shouldIgnoreEvent (activeElement, key) {
 
   // if the cursor is inside of a textarea/input, then don't focus to the next/previous element
   // unless the cursor is at the beginning or the end
-  if (key === 'ArrowLeft' && selectionStart === selectionEnd && selectionStart === 0) {
+  if (!forwardDirection && selectionStart === selectionEnd && selectionStart === 0) {
     return false
-  } else if (key === 'ArrowRight' && selectionStart === selectionEnd && selectionStart === len) {
+  } else if (forwardDirection && selectionStart === selectionEnd && selectionStart === len) {
     return false
   }
   return true
 }
 
+function getNextNode (root, targetElement, forwardDirection): HTMLElement {
+  var filter: NodeFilter = {
+    acceptNode: function (node: HTMLElement) {
+      var accept = (node === targetElement || node.shadowRoot || isFocusable(node))
+      return accept ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP
+    }
+  }
+  var walker: TreeWalker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT, filter)
+  if (targetElement) {
+    walker.currentNode = targetElement
+  }
+
+  var nextNode: HTMLElement
+
+  if (forwardDirection) {
+    nextNode = walker.nextNode() as HTMLElement
+  } else if (targetElement) {
+    nextNode = walker.previousNode() as HTMLElement
+  } else { // iterating backwards through shadow root, use last child
+    nextNode = walker.lastChild() as HTMLElement
+  }
+
+  if (nextNode && nextNode.shadowRoot) { // push into the shadow DOM
+    return getNextNode(nextNode.shadowRoot, null, forwardDirection)
+  }
+  if (!nextNode && root.host) { // pop out of the shadow DOM
+    return getNextNode(root.host.getRootNode(), root.host, forwardDirection)
+  }
+  return nextNode
+}
+
 function focusNextOrPrevious (event, key) {
-  var activeElement = document.activeElement
-  if (shouldIgnoreEvent(activeElement, key)) {
+  var activeElement = getActiveElement()
+  var forwardDirection = key === 'ArrowRight'
+  if (shouldIgnoreEvent(activeElement, forwardDirection)) {
     return
   }
-  var focusableElements = getFocusableElements(activeElement)
-  if (!focusableElements.length) {
-    return
+  var root = getFocusTrapParent(activeElement) || activeElement.getRootNode()
+  var nextNode = getNextNode(root, activeElement, forwardDirection)
+  if (nextNode && nextNode !== activeElement) {
+    nextNode.focus()
+    event.preventDefault()
   }
-  var index = focusableElements.indexOf(activeElement)
-  var element
-  if (key === 'ArrowLeft') {
-    element = focusableElements[index - 1] || focusableElements[0]
-  } else { // ArrowRight
-    element = focusableElements[index + 1] || focusableElements[focusableElements.length - 1]
-  }
-  element.focus()
-  event.preventDefault()
 }
 
 function handleEnter (event) {
-  var activeElement = document.activeElement
+  var activeElement = getActiveElement()
   if (activeElement.tagName === 'INPUT' &&
     checkboxRadioInputTypes.indexOf(activeElement.getAttribute('type').toLowerCase()) !== -1) {
     // Explicitly override "enter" on an input and make it fire the checkbox/radio

--- a/test/test.js
+++ b/test/test.js
@@ -26,6 +26,9 @@ function putCursorAtStart(el) {
 // keep track of the active element before the library does anything
 function onKeyDownBefore () {
   oldActiveElement = document.activeElement
+  if (oldActiveElement.shadowRoot) {
+    oldActiveElement = oldActiveElement.shadowRoot.activeElement
+  }
 }
 
 function isTextInput (element) {
@@ -105,6 +108,14 @@ function typeEnter () {
 
 function assertActiveClass (className) {
   assert.deepStrictEqual([...document.activeElement.classList], className)
+}
+
+function assertShadowActiveClass (className) {
+  let activeElement = document.activeElement
+  while (activeElement.shadowRoot) {
+    activeElement = activeElement.shadowRoot.activeElement
+  }
+  assert.deepStrictEqual([...activeElement.classList], className)
 }
 
 describe('test suite', () => {
@@ -326,6 +337,152 @@ describe('test suite', () => {
       assertActiveClass(['input'])
       typeLeft()
       assertActiveClass(['input'])
+    })
+  })
+
+  describe('shadow dom', () => {
+    it('works with shadow dom', () => {
+      class Component extends HTMLElement {
+        constructor() {
+          super()
+          this.attachShadow({ mode: 'open'})
+          this.shadowRoot.innerHTML = `
+            <button class="inside-shadow-button-1">
+            <input type=text class="inside-shadow-text" value='hi'>
+            <button class="inside-shadow-button-2">
+          `
+          this.classList.add('my-component')
+        }
+      }
+      customElements.define('my-component', Component)
+
+      document.body.innerHTML = `
+        <button class="button-1">one</button>
+        <my-component></my-component>
+        <button class="button-2">two</button>
+      `
+      typeRight()
+      assertActiveClass(['button-1'])
+      typeRight()
+      assertActiveClass(['my-component'])
+      assertShadowActiveClass(['inside-shadow-button-1'])
+      typeRight()
+      assertShadowActiveClass(['inside-shadow-text'])
+      typeRight()
+      assertShadowActiveClass(['inside-shadow-text'])
+      typeRight()
+      assertShadowActiveClass(['inside-shadow-text'])
+      typeRight()
+      assertShadowActiveClass(['inside-shadow-button-2'])
+      typeRight()
+      assertActiveClass(['button-2'])
+      typeLeft()
+      assertActiveClass(['my-component'])
+      assertShadowActiveClass(['inside-shadow-button-2'])
+      typeLeft()
+      assertShadowActiveClass(['inside-shadow-text'])
+      typeLeft()
+      assertShadowActiveClass(['inside-shadow-text'])
+      typeLeft()
+      assertShadowActiveClass(['inside-shadow-text'])
+      typeLeft()
+      assertShadowActiveClass(['inside-shadow-button-1'])
+      typeLeft()
+      assertActiveClass(['button-1'])
+    })
+
+    it('works with shadow dom inside shadow dom', () => {
+      class Component2 extends HTMLElement {
+        constructor() {
+          super()
+          this.attachShadow({ mode: 'open'})
+          this.shadowRoot.innerHTML = `
+            <span>not focusable</span>
+            <my-component-3></my-component-3>
+            <span>not focusable</span>
+          `
+          this.classList.add('my-component-2')
+        }
+      }
+
+      class Component3 extends HTMLElement {
+        constructor() {
+          super()
+          this.attachShadow({ mode: 'open'})
+          this.shadowRoot.innerHTML = `
+            <span>not focusable</span>
+            <button class="inside-shadow-button">button</button>
+            <span>not focusable</span>
+          `
+          this.classList.add('my-component-3')
+        }
+      }
+
+      customElements.define('my-component-2', Component2)
+      customElements.define('my-component-3', Component3)
+
+      document.body.innerHTML = `
+        <button class="button-1">one</button>
+        <my-component-2></my-component-2>
+        <button class="button-2">two</button>
+      `
+      typeRight()
+      assertActiveClass(['button-1'])
+      typeRight()
+      assertActiveClass(['my-component-2'])
+      assertShadowActiveClass(['inside-shadow-button'])
+      typeRight()
+      assertActiveClass(['button-2'])
+      typeLeft()
+      assertActiveClass(['my-component-2'])
+      assertShadowActiveClass(['inside-shadow-button'])
+      typeLeft()
+      assertActiveClass(['button-1'])
+    })
+
+    it('works with shadow dom inside shadow dom 2', () => {
+      class Component4 extends HTMLElement {
+        constructor() {
+          super()
+          this.attachShadow({ mode: 'open'})
+          this.shadowRoot.innerHTML = `
+            <my-component-5></my-component-5>
+          `
+          this.classList.add('my-component-4')
+        }
+      }
+
+      class Component5 extends HTMLElement {
+        constructor() {
+          super()
+          this.attachShadow({ mode: 'open'})
+          this.shadowRoot.innerHTML = `
+            <button class="inside-shadow-button">button</button>
+          `
+          this.classList.add('my-component-5')
+        }
+      }
+
+      customElements.define('my-component-4', Component4)
+      customElements.define('my-component-5', Component5)
+
+      document.body.innerHTML = `
+        <button class="button-1">one</button>
+        <my-component-4></my-component-4>
+        <button class="button-2">two</button>
+      `
+      typeRight()
+      assertActiveClass(['button-1'])
+      typeRight()
+      assertActiveClass(['my-component-4'])
+      assertShadowActiveClass(['inside-shadow-button'])
+      typeRight()
+      assertActiveClass(['button-2'])
+      typeLeft()
+      assertActiveClass(['my-component-4'])
+      assertShadowActiveClass(['inside-shadow-button'])
+      typeLeft()
+      assertActiveClass(['button-1'])
     })
   })
 })


### PR DESCRIPTION
Switches to a slightly-less efficient TreeWalker implementation in order to add Shadow DOM support. Using TreeWalker allows us to iterate through the DOM in DOM order to find focusable elements.